### PR TITLE
nil errors.

### DIFF
--- a/TidyPlates/TidyPlatesCore.lua
+++ b/TidyPlates/TidyPlatesCore.lua
@@ -329,7 +329,8 @@ do
 	function UpdateIndicator_CustomAlpha()
 		if activetheme.SetAlpha then
 			local previousAlpha = extended.requestedAlpha
-			extended.requestedAlpha = activetheme.SetAlpha(unit) or previousAlpha or unit.alpha or 1
+			local computedAlpha = activetheme.SetAlpha(unit)
+			extended.requestedAlpha = computedAlpha or previousAlpha or unit.alpha or 1
 		else
 			extended.requestedAlpha = unit.alpha or 1
 		end

--- a/TidyPlates/hub/Functions.lua
+++ b/TidyPlates/hub/Functions.lua
@@ -233,7 +233,7 @@ end
 -- By Threat (High)
 local function AlphaFunctionByThreatHigh(unit)
 	if InCombatLockdown() and unit.reaction == "HOSTILE" then
-		if unit.threatValue > 1 and unit.health > 0 then
+		if unit.threatValue and unit.health and unit.threatValue > 1 and unit.health > 0 then
 			return LocalVars.OpacitySpotlight
 		end
 	end
@@ -245,7 +245,7 @@ local function AlphaFunctionByThreatLow(unit)
 		if IsTankedByAnotherTank(unit) then
 			return
 		end
-		if unit.threatValue < 2 and unit.health > 0 then
+		if unit.threatValue and unit.health and unit.threatValue < 2 and unit.health > 0 then
 			return LocalVars.OpacitySpotlight
 		end
 	end
@@ -297,7 +297,7 @@ local function AlphaFilter(unit)
 	elseif LocalVars.OpacityFilterNonElite and (not unit.isElite) then
 		return true
 	elseif LocalVars.OpacityFilterInactive then
-		if unit.reaction ~= "FRIENDLY" and not (unit.isInCombat or unit.threatValue > 0 or unit.health < unit.healthmax) then
+		if unit.reaction ~= "FRIENDLY" and not (unit.isInCombat or (unit.threatValue and unit.threatValue > 0) or (unit.health and unit.healthmax and unit.health < unit.healthmax)) then
 			return true
 		end
 	end
@@ -341,6 +341,7 @@ end
 
 local function AlphaDelegate(...)
 	local unit = ...
+	if not unit then return end
 	local alpha
 
 	if unit.isTarget then


### PR DESCRIPTION
Fix some nil errors, when there are a lot of nameplates needs to be processed with Tank-threadLow setup.
I've been receiving some nil errors:
<error>
Message: Interface\AddOns\TidyPlates\hub\Functions.lua:300: attempt to compare number with nil
Time: 03/21/25 13:24:49
Count: 1
Stack: [C]: ?
Interface\AddOns\TidyPlates\hub\Functions.lua:300: in function <Interface\AddOns\TidyPlates\hub\Functions.lua:292>
Interface\AddOns\TidyPlates\hub\Functions.lua:352: in function SetAlpha'
Interface\AddOns\TidyPlates\TidyPlatesCore.lua:332: in function <Interface\AddOns\TidyPlates\TidyPlatesCore.lua:329>
Interface\AddOns\TidyPlates\TidyPlatesCore.lua:914: in function <Interface\AddOns\TidyPlates\TidyPlatesCore.lua:909>
Interface\AddOns\TidyPlates\TidyPlatesCore.lua:707: in function <Interface\AddOns\TidyPlates\TidyPlatesCore.lua:706>

Locals: 
</error>

This fix will make sure there is nameplates information available for addon, when there are a lot of nameplates/screenshake etc.